### PR TITLE
Bumped certbot-dns-freedns version to 0.2.0

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -170,7 +170,7 @@
 	"freedns": {
 		"name": "FreeDNS",
 		"package_name": "certbot-dns-freedns",
-		"version": "~=0.1.0",
+		"version": "~=0.2.0",
 		"dependencies": "",
 		"credentials": "dns_freedns_username = myremoteuser\ndns_freedns_password = verysecureremoteuserpassword",
 		"full_plugin_name": "dns-freedns"


### PR DESCRIPTION
bumped certbot-dns-freedns to 0.2.0 https://pypi.org/project/certbot-dns-freedns/0.2.0/ 

Fix problems creating the _acme txt entry if you are not a paid subscriber see issue: https://github.com/schleuss/certbot_dns_freedns/issues/1

With current version, the challenge fail and you get an error llike. This fix #2352

```
2024-05-13 20:37:35,988:ERROR:certbot._internal.error_handler:Encountered exception during recovery: AttributeError: 'NoneType' object has no attribute 'get'
2024-05-13 20:37:35,990:DEBUG:certbot._internal.log:Exiting abnormally:
Traceback (most recent call last):
  File "/opt/certbot/bin/certbot", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/main.py", line 19, in main
    return internal_main.main(cli_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/main.py", line 1894, in main
    return config.func(config, plugins)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/main.py", line 1600, in certonly
    lineage = _get_and_save_cert(le_client, config, domains, certname, lineage)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/main.py", line 143, in _get_and_save_cert
    lineage = le_client.obtain_and_enroll_certificate(domains, certname)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/client.py", line 517, in obtain_and_enroll_certificate
    cert, chain, key, _ = self.obtain_certificate(domains)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/client.py", line 428, in obtain_certificate
    orderr = self._get_order_and_authorizations(csr.data, self.config.allow_subset_of_names)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/client.py", line 496, in _get_order_and_authorizations
    authzr = self.auth_handler.handle_authorizations(orderr, self.config, best_effort)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/_internal/auth_handler.py", line 88, in handle_authorizations
    resps = self.auth.perform(achalls)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot/plugins/dns_common.py", line 76, in perform
    self._perform(domain, validation_domain_name, validation)
  File "/opt/certbot/lib/python3.11/site-packages/certbot_dns_freedns/dns_freedns.py", line 56, in _perform
    self._get_freedns_client().add_txt_record(
  File "/opt/certbot/lib/python3.11/site-packages/certbot_dns_freedns/dns_freedns.py", line 115, in add_txt_record
    record = self.get_existing_txt(zone_id, record_name, record_content)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot_dns_freedns/dns_freedns.py", line 191, in get_existing_txt
    zone_data = self._load_domain_data(zone_id, record_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot_dns_freedns/dns_freedns.py", line 268, in _load_domain_data
    full_data = self._load_txt_record(domain_id, freedns_record_id, freedns_record_type)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/certbot/lib/python3.11/site-packages/certbot_dns_freedns/dns_freedns.py", line 286, in _load_txt_record
    input_ttl = soup.find("input", recursive=True, attrs={"name": "ttl"}).get("value")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
2024-05-13 20:37:35,994:ERROR:certbot._internal.log:An unexpected error occurred:
2024-05-13 20:37:35,995:ERROR:certbot._internal.log:AttributeError: 'NoneType' object has no attribute 'get'
```
